### PR TITLE
Refactor taxonomy cloud widget for clarity

### DIFF
--- a/layouts/partials/widgets/taxonomy_cloud.html
+++ b/layouts/partials/widgets/taxonomy_cloud.html
@@ -1,31 +1,28 @@
 {{- $defaultConfig := .Site.Data.config.default.widgets.taxonomy_cloud -}}
-{{- $configData := ( or .Site.Data.config.widgets.taxonomy_cloud $defaultConfig ) -}}
+{{- $configData := (or .Site.Data.config.widgets.taxonomy_cloud $defaultConfig) -}}
 {{- $lang := .Site.Language.Lang -}}
-{{- $config := ( ( index $configData $lang ) | default $configData ) -}}
+{{- $config := ((index $configData $lang) | default $configData) -}}
 
-{{- $shuffle := ( $config.shuffle | default false ) -}}
-{{- $taxonomy1 := ( $config.taxonomy | default "tags" ) -}}
-{{- $taxonomyData1 := ( .Site.GetPage $taxonomy1 ).Data -}}
+{{- $shuffle := ($config.shuffle | default false) -}}
+{{- $taxonomy1 := ($config.taxonomy | default "tags") -}}
+{{- $taxonomyData1 := (.Site.GetPage $taxonomy1).Data -}}
 {{- $taxonomySingular1 := $taxonomyData1.Singular -}}
 
-{{- $taxonomy2 := (default "categories" ) -}}
-{{- $taxonomyData2 := ( .Site.GetPage $taxonomy2 ).Data -}}
+{{- $taxonomy2 := "categories" -}}
+{{- $taxonomyData2 := (.Site.GetPage $taxonomy2).Data -}}
 {{- $taxonomySingular2 := $taxonomyData2.Singular -}}
 
+{{- $ctx := . -}}
+{{- $taxonomies := slice
+    (dict "name" $taxonomy2 "title" (i18n $taxonomySingular2 2))
+    (dict "name" $taxonomy1 "title" ($config.title | default (i18n $taxonomySingular1 2)))
+-}}
+
 <section class='widget widget-taxonomy_cloud sep-after'>
-  <h4 class='title widget-title'>
-    {{- (default ( i18n $taxonomySingular2 2 ) ) -}}
-  </h4>
-  </header>
-
-  {{ partial "extras/taxonomy_cloud" ( dict "Taxonomy" $taxonomy2 "Shuffle" $shuffle "Scope" . ) }}
-  
-  <header>
-    <h4 class='title widget-title'>
-      {{- ( $config.title | default ( i18n $taxonomySingular1 2 ) ) -}}
-    </h4>
-  </header>
-
-  {{ partial "extras/taxonomy_cloud" ( dict "Taxonomy" $taxonomy1 "Shuffle" $shuffle "Scope" . ) }}
-
+  {{- range $taxonomies }}
+    <header>
+      <h4 class='title widget-title'>{{- .title -}}</h4>
+    </header>
+    {{ partial "extras/taxonomy_cloud" (dict "Taxonomy" .name "Shuffle" $shuffle "Scope" $ctx) }}
+  {{- end }}
 </section>


### PR DESCRIPTION
## Summary
- simplify taxonomy cloud widget by looping through configured taxonomies
- fix header markup and handle default titles

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68a1a68b8cc0832db69ba7d371e30137