### PR TITLE
Move language param under languages.en.params

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,4 @@
+
 baseURL = "https://michaelye48.github.io/portfolio-website"
 title = "Michael's Portfolio"
 # for smart copyright line, leave this blank and check [params.copyright]
@@ -139,6 +140,8 @@ hrefTargetBlank = true
 [languages]
 # edit this block for your own language
 [languages.en]
-lang = "en"
 languageName = "English"
 weight = 1
+
+[languages.en.params]
+lang = "en"


### PR DESCRIPTION
## Summary
- eliminate Hugo config deprecation by nesting `lang` under `languages.en.params`

## Testing
- `hugo --panicOnWarning` *(fails: found no layout file for "html" for kind "home")*

------
https://chatgpt.com/codex/tasks/task_e_68a1a823da30832d95ea6ad801d8b73f